### PR TITLE
Fix Hugo partial paths

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -5,6 +5,7 @@ title = 'Sarkastický blog o programování - blog.pepamraz.cz 💻'
 theme = 'PaperMod'
 relativeURLs = true
 canonifyURLs = true
+ignoreLogs = ['warning-partial-superfluous-prefix']
 
 [params]
 [params.homeInfoParams]

--- a/themes/PaperMod/layouts/partials/head.html
+++ b/themes/PaperMod/layouts/partials/head.html
@@ -151,7 +151,7 @@
 {{- /* Misc */}}
 {{- if hugo.IsProduction | or (eq site.Params.env "production") }}
 {{- template "_internal/google_analytics.html" . }}
-{{- template "partials/templates/opengraph.html" . }}
-{{- template "partials/templates/twitter_cards.html" . }}
-{{- template "partials/templates/schema_json.html" . }}
+{{- template "templates/opengraph.html" . }}
+{{- template "templates/twitter_cards.html" . }}
+{{- template "templates/schema_json.html" . }}
 {{- end -}}

--- a/themes/PaperMod/layouts/partials/templates/opengraph.html
+++ b/themes/PaperMod/layouts/partials/templates/opengraph.html
@@ -10,7 +10,7 @@
 {{- end}}
 {{- else }}
 
-{{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+{{- $images := partial "templates/_funcs/get-page-images" . -}}
 {{- range first 6 $images }}
 <meta property="og:image" content="{{ .Permalink }}" />
 {{ end -}}

--- a/themes/PaperMod/layouts/partials/templates/schema_json.html
+++ b/themes/PaperMod/layouts/partials/templates/schema_json.html
@@ -81,7 +81,7 @@
     {{ (path.Join .RelPermalink .Params.cover.image ) | absURL }},
     {{- end}}
   {{- else }}
-    {{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+    {{- $images := partial "templates/_funcs/get-page-images" . -}}
     {{- with index $images 0 -}}
   "image": {{ .Permalink }},
     {{- end }}

--- a/themes/PaperMod/layouts/partials/templates/twitter_cards.html
+++ b/themes/PaperMod/layouts/partials/templates/twitter_cards.html
@@ -6,7 +6,7 @@
 <meta name="twitter:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}" />
 {{- end}}
 {{- else }}
-{{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+{{- $images := partial "templates/_funcs/get-page-images" . -}}
 {{- with index $images 0 -}}
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="{{ .Permalink }}" />


### PR DESCRIPTION
## Summary
- fix partial calls in PaperMod templates
- silence `warning-partial-superfluous-prefix`

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_684263194ae08330ae05d0d647f23733